### PR TITLE
fix: set default values for birthyear and gender in the access token …

### DIFF
--- a/internal/handler/loginV2.go
+++ b/internal/handler/loginV2.go
@@ -101,7 +101,7 @@ func LoginV2(rdb *redis.Client, db *sql.DB) func(c *gin.Context) {
 			go CreatePlaylist(db, m.Nickname.String+null.StringFrom("의 플레이리스트").String, m.MemberID)
 			go ActivateDeviceToken(db, loginRequest.DeviceToken, m.MemberID)
 
-			accessTokenString, refreshTokenString, tokenErr := createAccessTokenAndRefreshTokenV2(c, rdb, payload, strconv.Itoa(m.Birthyear.Int), m.Gender.String, m.MemberID)
+			accessTokenString, refreshTokenString, tokenErr := createAccessTokenAndRefreshTokenV2(c, rdb, payload, "0", "Unknown", m.MemberID)
 
 			if tokenErr != nil {
 				pkg.BaseResponse(c, http.StatusInternalServerError, "error - cannot create token "+tokenErr.Error(), nil)


### PR DESCRIPTION
…when first login

문제: 최초 회원가입시 access token에 birthyear, gender가 잘못 초기화되어 인기차트에서 활용할 수 없던 점
둥둥이가 동작안하길래 일단 가장 편한 방법으로 해결~

